### PR TITLE
proposed revision of yt governance 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+if not on_rtd:
+    import sphinx_rtd_theme
+    html_theme = "sphinx_rtd_theme"
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'yt-governance'
+copyright = '2019, yt-project'
+author = 'yt-project'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/source/general.rst
+++ b/source/general.rst
@@ -29,7 +29,7 @@ through the following procedure:
   governance model
 * The pull request is announced in public channels available to the community and 
   must be discussed at the next steering committee meeting.
-* The alternative model is accepted by more than half of the active maintainers 
+* The alternative model is accepted by more than half of the active members 
   of that repository and at least two executive committee members.
 
 Unless specifically stated otherwise this governance document and topics within

--- a/source/general.rst
+++ b/source/general.rst
@@ -1,0 +1,62 @@
+.. _general:
+
+##########################
+General Project Guidelines
+##########################
+
+Code of Conduct
+---------------
+
+All members participating in the yt project community, whether that be on
+github, mailing lists, workshops, or in any other capacity are expected to
+abide by the `code of conduct
+<https://yt-project.org/doc/developing/developing.html#yt-community-code-of-conduct>`_.
+
+If any person feels a member of the yt project community has violated the code
+of conduct, a report can be made to a project member or sent to
+confidential@yt-project.org. Reports of CoC violations will be treated with the
+strictest confidence.
+
+Where the Governance Applies
+----------------------------
+
+This governance document applies to all repositories hosted within the yt
+project organization. If a package proposes an alteration to this governance
+model, it can be further refined in that repository, but must be implemented
+through the following procedure:
+
+* A pull request is made to that repository with a proposed alternative 
+  governance model
+* The pull request is announced in public channels available to the community and 
+  must be discussed at the next steering committee meeting.
+* The alternative model is accepted by more than half of the active maintainers 
+  of that repository and at least two executive committee members.
+
+Unless specifically stated otherwise this governance document and topics within
+will apply to all repositories within the organization.
+
+Package Licensing
+-----------------
+
+Licensing projects within the yt project is open for discussion. The core yt
+package is licensed with BSD-3, but supporting packages may choose alternative
+licenses depending on the needs of the repository. The community broadly
+recommends using BSD-3.
+
+Conflicts of Interest
+---------------------
+
+It is expected that the Steering Committee Members will be
+employed at a wide range of companies, universities and non-profit
+organizations. Because of this, it is possible that Members will have conflict
+of interests. Such conflict of interests include, but are not limited to:
+
+* Financial interests, such as investments, employment or contracting work, 
+  outside of The Project that may influence their work on The Project.
+* Access to proprietary information of their employer that could potentially leak
+  into their work with the Project.
+
+All members of the Steering Committee shall disclose to
+the rest of the Council any conflict of interest they may have. Members with a
+conflict of interest in a particular issue may participate in Committee
+discussions on that issue, but must recuse themselves from voting on the issue.

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,0 +1,41 @@
+.. yt-governance documentation master file, created by
+   sphinx-quickstart on Fri Aug  9 17:45:26 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+yt project governance 
+=====================
+
+The mission of the yt project is to create tools to visualize, analyze, and
+explore scientific data for the natural sciences. The core package of the yt
+project is `yt <https://yt-project.org/>`_, but our `organization
+<https://github.com/yt-project>`_ includes a number of packages that lie within
+this theme. 
+
+The purpose of these pages are to formalize the governance structure of the
+core yt package and packages hosted within the yt project github organization.
+Broadly, these pages provide an overview of our values, decision-making
+processes, and how the project is organized. Our governance aims to embue the
+following principles:
+
+* Project openness & transparency
+* An active, welcoming environment for contribution
+* An inclusive, welcoming environment for users of all skill levels
+* Institutional neutrality
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   general
+   roles
+   leadership
+   meetings
+   voting
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,7 +8,7 @@ yt project governance
 
 The mission of the yt project is to create tools to visualize, analyze, and
 explore scientific data for the natural sciences. The core package of the yt
-project is `yt <https://yt-project.org/>`_, but our `organization
+project is `yt <https://github.com/yt-project/yt>`_, but our `organization
 <https://github.com/yt-project>`_ includes a number of packages that lie within
 this theme. 
 

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -29,38 +29,6 @@ for membership and provides a list of all members and the year in which
 membership was granted. Members have write access to all official yt
 repositories and can, therefore, accept and merge pull requests.
 
-Subproject Teams
-----------------
-
-To help foster a network of maintainer mentorship and to make maintenance of
-the yt project more sustainable, we have opted for a leader/deputy model for
-areas within the yt project that may have some thematic maintenance experts.
-The subproject leader is the primary point of contact for maintenance of that
-subproject, and may help onboard and mentor new maintainers of the subproject,
-who are the deputies. Deputies may self-nominate to become deputies. Being a
-lead or deputy on a project does not limit maintenance in other aspects of the
-project, we are merely aiming for some distributed responsibility of
-maintenance efforts across the community. We invite members of the community to
-self-nominate to fill empty roles of leaders or deputies of subprojects, or to
-self-nominate to become leaders of newly proposed subprojects. 
-
-The initial project/subproject teams are:
-
-.. admonition:: within the organization
-
-   * yt-project infrastructure (including website and yt hub)
-   * analysis modules (one lead/deputy for each analysis module)
-   * unyt
-
-.. admonition:: within the yt core package
-
-   * domain contexts (general domain infrastructure)
-   * yt testing (answer testing, unit testing, and CI)
-   * frontends (one lead who understands generic frontend infrastructure, 
-     deputy for each specific frontend)
-   * visualization
-   * documentation (narrative docs and examples)
-
 Groups Within the yt Project
 ----------------------------
 
@@ -70,7 +38,7 @@ contributors, reviewers and maintainers of the project. Each color-coded group
 encompasses many members of the community, but hopefully will help to direct
 and distribute project member energy.
 
-**Red Group** (includes executive committee, and all subproject leaders) –
+**Red Group** (includes executive committee, any defined leadership roles) –
 Members of this group spend a large part of their time organizing the
 yt-project from a high level. They are expected to coordinate their actions
 with other red members so that the project presents a coherent position towards
@@ -84,7 +52,7 @@ the next monthly team meeting. Red group members are expected to also perform
 duties of blue group members while facilitating and helping the blue group to
 grow.
 
-**Blue Group** (includes all subproject deputies and yt project members) – This
+**Blue Group** (includes all yt project members) – This
 is where the journey of a new yt project team member starts. Blue group members
 spend a large part of your time facilitating contributions from others to the
 project (e.g. reviewing work, answering questions, maintaining project

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -22,7 +22,7 @@ contributions to the project while also rescinding their write access to the
 project. 
 
 Upon the initial creation of yt membership status, all
-developers that had contributed at least 50 changesets were be granted
+developers that had contributed at least 50 changesets were granted
 membership. The `Project Members page <https://yt-project.org/members.html>`_ 
 gives a description of the requirements
 for membership and provides a list of all members and the year in which
@@ -46,21 +46,20 @@ self-nominate to become leaders of newly proposed subprojects.
 
 The initial project/subproject teams are:
 
-**within the organization**
+.. admonition:: within the organization
 
-* yt-project infrastructure (including website and yt hub)
-* analysis modules (one lead/deputy for each analysis module)
-* unyt
+   * yt-project infrastructure (including website and yt hub)
+   * analysis modules (one lead/deputy for each analysis module)
+   * unyt
 
-**within the yt core package**
+.. admonition:: within the yt core package
 
-* domain contexts (general domain infrastructure)
-* yt testing (answer testing, unit testing, and CI)
-* frontends (one lead who understands generic frontend infrastructure, 
-  deputy for each specific frontend)
-* visualization
-* documentation (narrative docs and examples)
-* triage
+   * domain contexts (general domain infrastructure)
+   * yt testing (answer testing, unit testing, and CI)
+   * frontends (one lead who understands generic frontend infrastructure, 
+     deputy for each specific frontend)
+   * visualization
+   * documentation (narrative docs and examples)
 
 Groups Within the yt Project
 ----------------------------
@@ -122,12 +121,13 @@ yt-exec@googlegroups.com.
 Steering Committee
 ------------------
 
-Members are eligible to serve on the yt project steering committee. The
+Members are eligible to serve on the yt project steering committee (also
+sometimes referred to as the executive committee). The
 steering committe shall meet quarterly or more often as needed to discuss
 project-related business. Members may join the steering committee by attending
 one of the team meetings and self-nominating. Once nominated, a nominee's entry
 to the steering committee will be voted on by members of the steering committee
-by a vote ratio exceeding 3/5. One person on the steering
+by a vote ratio equal or exceeding to 3/5. One person on the steering
 committee shall act as the coordinator, in charge of making sure the team
 meetings happen. All developers are welcome to participate in team meetings.
 

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -38,17 +38,17 @@ contributors, reviewers and maintainers of the project. Each color-coded group
 encompasses many members of the community, but hopefully will help to direct
 and distribute project member energy.
 
-**Red Group** (includes executive committee, any defined leadership roles) –
+**Leadership Group** (includes executive committee, any defined leadership roles) –
 Members of this group spend a large part of their time organizing the
 yt-project from a high level. They are expected to coordinate their actions
 with other red members so that the project presents a coherent position towards
 the outside. They are expected to prepare and attend the monthly team calls and
-executive committee meetings. We expect red members to teach and grow other
+executive committee meetings. We expect leadership members to teach and grow other
 members so that they can pass their organizational responsibilities on to them.
 This encourages us to increase diversity, reduce burn-out and allow group
 members to shift their focus in reaction to changing life circumstances. If a
 red member chooses to change focus, that change of focus will be announced at
-the next monthly team meeting. Red group members are expected to also perform
+the next monthly team meeting. Leadership group members are expected to also perform
 duties of blue group members while facilitating and helping the blue group to
 grow.
 
@@ -64,17 +64,18 @@ volunteering for tasks which a red member is expected to perform. After a while
 of doing so the group will ask if you want to become a red member and, if you
 agree, recognise you as such at a monthly team meeting.
 
-**Yellow Group** - Yellow group members are new contributors to the yt-project.
-Yellow group members do not have commit access to the yt project yet, but may
+**Wellspring Group** - The wellspring group members are new contributors to the yt-project.
+Wellspring members do not have commit access to the yt project yet, but may
 have submitted a bugfix or documentation improvement and would like to
-contribute more. Yellow group members do not have high-level project
+contribute more. Wellspring members do not have high-level project
 responsibility, but may start to seek out involvement in the project by
-attending triage meetings. 
+attending triage meetings. Wellspring group members will be offered triage rights to
+the project on github in their merged pull request. 
 
-**Green Group** (can be any person, any time, self-nominated only)-- This group
+**Sabbatical Group** (can be any person, any time, self-nominated only)-- This group
 applies to members of the community whose life situation has changed so that
 they prefer to (temporarily) not take on the rights and responsibilities of
-being an active member. Membership to the green group is invoked by
+being an active member. Membership to the sabbatical group is invoked by
 self-nomination. They can return to active membership by resuming their
 community activities. Their return will be announced at the next team meeting
 or via the developers mailing list.

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -117,8 +117,18 @@ member must be associated with each leadership role defined below. Members that
 wish to roll off of a leadership role may do so by announcing at a team
 meeting, and a new member will self-nominate to fill the position. If
 multiple members self-nominate, then members of the steering committee will
-vote to instate the new leader. Members that are in a defined leadership role
-are not necessarily steering committee members, but are red group members.  
+vote to instate the new leader. 
+
+As the project matures, a new leadership position
+may present itself based on a member taking on a specific role within the
+project. A member may present this new leadership position in the governance
+documentation repository as an issue or bring it up in a yt project team
+meeting, where members of the project will decide whether to add it to these
+defined roles. 
+
+Members that are in a defined leadership role
+are not necessarily steering committee members, but are considered 
+red group members. 
 
 **Mentorship Shepherd** -- The mentorship shepherd helps to grow yellow group 
 members to blue group members. The mentorship shepherd will help yellow members

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -1,8 +1,8 @@
 .. _leadership:
 
-##################
-Project Leadership 
-##################
+#############
+Project Roles 
+#############
 
 yt-project Members
 ------------------
@@ -38,44 +38,48 @@ contributors, reviewers and maintainers of the project. Each color-coded group
 encompasses many members of the community, but hopefully will help to direct
 and distribute project member energy.
 
-**Leadership Group** (includes executive committee, any defined leadership roles) –
+**Fertilizer Group** (includes executive committee, any defined leadership roles) –
 Members of this group spend a large part of their time organizing the
 yt-project from a high level. They are expected to coordinate their actions
-with other red members so that the project presents a coherent position towards
+with other fertilizer members so that the project presents a coherent position towards
 the outside. They are expected to prepare and attend the monthly team calls and
-executive committee meetings. We expect leadership members to teach and grow other
+executive committee meetings. We expect fertilizer members to teach and grow other
 members so that they can pass their organizational responsibilities on to them.
 This encourages us to increase diversity, reduce burn-out and allow group
 members to shift their focus in reaction to changing life circumstances. If a
-red member chooses to change focus, that change of focus will be announced at
-the next monthly team meeting. Leadership group members are expected to also perform
-duties of blue group members while facilitating and helping the blue group to
+fertilizer member chooses to change focus, that change of focus will be announced at
+the next monthly team meeting. Fertilizer group members are expected to also perform
+duties of arboretum group members while facilitating and helping the arboretum group to
 grow.
 
-**Blue Group** (includes all yt project members) – This
-is where the journey of a new yt project team member starts. Blue group members
+**The Arboretum** (includes all yt project members and the leadership group) – This
+is where the journey of a new yt project team member starts. This group is the largest 
+within the project and includes all project members and leadership group. 
+Arboretum group members
 spend a large part of your time facilitating contributions from others to the
 project (e.g. reviewing work, answering questions, maintaining project
-infrastructure, doing triage of new issues). We expect blue members to teach
-and grow contributors that can become blue members. This encourages diversity
+infrastructure, doing triage of new issues). We expect arboretum members to teach
+and grow contributors that can become arboretum members. This encourages diversity
 of the project. After building a good understanding of the technology and
-social structure of the project blue members can change to a red member by
-volunteering for tasks which a red member is expected to perform. After a while
-of doing so the group will ask if you want to become a red member and, if you
+social structure of the project arboretum members can change to a fertilizer member by
+volunteering for tasks which a fertilizer member is expected to perform. After a while
+of doing so the group will ask if you want to become a fertilizer member and, if you
 agree, recognise you as such at a monthly team meeting.
 
-**Wellspring Group** - The wellspring group members are new contributors to the yt-project.
-Wellspring members do not have commit access to the yt project yet, but may
+**The Greenhouse** - Group members in the greenhouse are those that are 
+new contributors to the yt-project.
+Greenhouse members do not have commit access to the yt project yet, but may
 have submitted a bugfix or documentation improvement and would like to
-contribute more. Wellspring members do not have high-level project
+contribute more. Greenhouse members do not have high-level project
 responsibility, but may start to seek out involvement in the project by
-attending triage meetings. Wellspring group members will be offered triage rights to
+attending triage meetings. Greenhouse group members will be offered triage rights to
 the project on github in their merged pull request. 
 
-**Sabbatical Group** (can be any person, any time, self-nominated only)-- This group
+**The Fallow Fields** (can be any person, any time, self-nominated only)-- This group
 applies to members of the community whose life situation has changed so that
 they prefer to (temporarily) not take on the rights and responsibilities of
-being an active member. Membership to the sabbatical group is invoked by
+being an active member. They may require some time off from the projec to
+reenergize and contribute in a later season. Membership to the fallow fields is invoked by
 self-nomination. They can return to active membership by resuming their
 community activities. Their return will be announced at the next team meeting
 or via the developers mailing list.
@@ -128,13 +132,13 @@ meeting, where members of the project will decide whether to add it to these
 defined roles. 
 
 Members that are in a defined leadership role
-are not necessarily steering committee members, but are considered 
-red group members. 
+are not necessarily steering committee members. However, they are considered 
+fertilizer group members. 
 
-**Mentorship Shepherd** -- The mentorship shepherd helps to grow yellow group 
-members to blue group members. The mentorship shepherd will help yellow members
+**Mentorship Shepherd** -- The mentorship shepherd helps to grow greenhouse group 
+members to aboretum group members. The mentorship shepherd will help greenhouse members
 find bugs and issues that they may wish to approach in the future, and, if
-necessaary, contact a blue or red team member to assist the yellow member. 
+necessaary, contact a arboretum or fertilizer team member to assist the greenhouse member. 
 
 **Triage Leader** -- The triage leader is responsible for ensuring that triage
 meetings get scheduled and facilitaates member participation in the triage

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -1,0 +1,133 @@
+.. _leadership:
+
+##################
+Project Leadership 
+##################
+
+yt-project Members
+------------------
+
+A member is someone who has made continued and significant contribution to the
+project (changes to the codebase, discussion on mailing lists, feedback on pull
+requests, documentation, teaching, etc.) for some period of time. After such a
+period, potential new members are nominated for membership by an existing
+member and confirmed by positive votes from three additional members. Once a
+developer becomes a member, they remain a member for life. A member maintains
+the option to give up their membership and have their name removed from the
+list. Membership may be revoked for anyone who is deemed to be directly harmful
+to the project or the community upon a nomination by another member and five
+supporting member votes and an additional vote by the steering committee.
+Members may also elect to become emeritus members, and be recognized for their
+contributions to the project while also rescinding their write access to the
+project. 
+
+Upon the initial creation of yt membership status, all
+developers that had contributed at least 50 changesets were be granted
+membership. The `Project Members page <https://yt-project.org/members.html>`_ 
+gives a description of the requirements
+for membership and provides a list of all members and the year in which
+membership was granted. Members have write access to all official yt
+repositories and can, therefore, accept and merge pull requests.
+
+Subproject Teams
+----------------
+
+To help foster a network of maintainer mentorship and to make maintenance of
+the yt project more sustainable, we have opted for a leader/deputy model for
+areas within the yt project that may have some thematic maintenance experts.
+The subproject leader is the primary point of contact for maintenance of that
+subproject, and may help onboard and mentor new maintainers of the subproject,
+who are the deputies. Deputies may self-nominate to become deputies. Being a
+lead or deputy on a project does not limit maintenance in other aspects of the
+project, we are merely aiming for some distributed responsibility of
+maintenance efforts across the community. We invite members of the community to
+self-nominate to fill empty roles of leaders or deputies of subprojects, or to
+self-nominate to become leaders of newly proposed subprojects. 
+
+The initial project/subproject teams are:
+
+**within the organization**
+
+* yt-project infrastructure (including website and yt hub)
+* analysis modules (one lead/deputy for each analysis module)
+* unyt
+
+**within the yt core package**
+
+* domain contexts (general domain infrastructure)
+* yt testing (answer testing, unit testing, and CI)
+* frontends (one lead who understands generic frontend infrastructure, 
+  deputy for each specific frontend)
+* visualization
+* documentation (narrative docs and examples)
+* triage
+
+Groups Within the yt Project
+----------------------------
+
+The goal of the groups within the yt project is to help focus member energy so
+that the yt project can grow, nurture, and develop a healthy group of
+contributors, reviewers and maintainers of the project. Each color-coded group
+encompasses many members of the community, but hopefully will help to direct
+and distribute project member energy.
+
+**Red Group** (includes executive committee, and all subproject leaders) –
+Members of this group spend a large part of their time organizing the
+yt-project from a high level. They are expected to coordinate their actions
+with other red members so that the project presents a coherent position towards
+the outside. They are expected to prepare and attend the monthly team calls and
+executive committee meetings. We expect red members to teach and grow other
+members so that they can pass their organizational responsibilities on to them.
+This encourages us to increase diversity, reduce burn-out and allow group
+members to shift their focus in reaction to changing life circumstances. If a
+red member chooses to change focus, that change of focus will be announced at
+the next monthly team meeting. Red group members are expected to also perform
+duties of blue group members while facilitating and helping the blue group to
+grow.
+
+**Blue Group** (includes all subproject deputies and yt project members) – This
+is where the journey of a new yt project team member starts. Blue group members
+spend a large part of your time facilitating contributions from others to the
+project (e.g. reviewing work, answering questions, maintaining project
+infrastructure, doing triage of new issues). We expect blue members to teach
+and grow contributors that can become blue members. This encourages diversity
+of the project. After building a good understanding of the technology and
+social structure of the project blue members can change to a red member by
+volunteering for tasks which a red member is expected to perform. After a while
+of doing so the group will ask if you want to become a red member and, if you
+agree, recognise you as such at a monthly team meeting.
+
+**Green Group** (can be any person, any time, self-nominated only)-- This group
+applies to members of the community whose life situation has changed so that
+they prefer to (temporarily) not take on the rights and responsibilities of
+being an active member. Membership to the green group is invoked by
+self-nomination. They can return to active membership by resuming their
+community activities. Their return will be announced at the next team meeting
+or via the developers mailing list.
+
+**Emeritus Group** (time based or self-nominated)-- this group is for members
+of the community at any level that have a prolonged leave of member duties from
+the yt project. We welcome participation in the community for any length of
+time, and this is a way to retire from the project. A project member may become
+emeritus by self-nomination or by not interacting in a membership capacity on
+the yt project for over 2 years. After this time, a member of the executive
+committee will contact an inactive member and see if they wish to remain active
+or transition to an emeritus role. 
+
+Finally, members of the community that wish to not be associated with the yt
+project may request to be removed from any/all teams/groups/committees and
+documentation by e-mailing either confidential@yt-project.org or
+yt-exec@googlegroups.com.
+
+Steering Committee
+------------------
+
+Members are eligible to serve on the yt project steering committee. The
+steering committe shall meet quarterly or more often as needed to discuss
+project-related business. Members may join the steering committee by attending
+one of the team meetings and self-nominating. Once nominated, a nominee's entry
+to the steering committee will be voted on by members of the steering committee
+by a vote ratio exceeding 3/5. One person on the steering
+committee shall act as the coordinator, in charge of making sure the team
+meetings happen. All developers are welcome to participate in team meetings.
+

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -45,8 +45,8 @@ Groups Within the yt Project
 ----------------------------
 
 The goal of the groups within the yt project is to help focus member energy so
-that the yt project can grow, nurture, and develop a healthy group of
-contributors, reviewers and maintainers of the project. Each color-coded group
+that the yt project can grow, nurture, and develop a healthy pool of
+contributors, reviewers and maintainers of the project. Each group
 encompasses many members of the community, but hopefully will help to direct
 and distribute project member energy.
 

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -123,6 +123,16 @@ by a vote ratio equal or exceeding to 3/5. One person on the steering
 committee shall act as the coordinator, in charge of making sure the team
 meetings happen. All developers are welcome to participate in team meetings.
 
+Current Steering Committee Members
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Nathan Goldbaum
+| Madicken Munk
+| Britton Smith
+| Stephanie Tonnesen
+| Matthew Turk
+| John ZuHone
+
 Defined Leadership Roles
 ------------------------
 
@@ -165,5 +175,12 @@ project in all ways time. This involves sending out polls to determine members'
 availability for meetings, scheduling those meetings, and running or ensuring a
 member is running a meeting. The timekeeper will announce all public meetings
 on project mailing lists, in the project slack, and, when relevant, on the
-project social media channels.  
+project social media channels.
+
+Current Leadership Members
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| **Mentorship Shepherd** -- Stephanie Tonnesen
+| **Triage Leader** -- Matthew Turk
+| **The Timekeeper** -- Britton Smith
 

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -96,6 +96,13 @@ volunteering for tasks which a red member is expected to perform. After a while
 of doing so the group will ask if you want to become a red member and, if you
 agree, recognise you as such at a monthly team meeting.
 
+**Yellow Group** - Yellow group members are new contributors to the yt-project.
+Yellow group members do not have commit access to the yt project yet, but may
+have submitted a bugfix or documentation improvement and would like to
+contribute more. Yellow group members do not have high-level project
+responsibility, but may start to seek out involvement in the project by
+attending triage meetings. 
+
 **Green Group** (can be any person, any time, self-nominated only)-- This group
 applies to members of the community whose life situation has changed so that
 they prefer to (temporarily) not take on the rights and responsibilities of

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -29,6 +29,18 @@ for membership and provides a list of all members and the year in which
 membership was granted. Members have write access to all official yt
 repositories and can, therefore, accept and merge pull requests.
 
+.. important::
+   We require that all members have two factor authentication (2FA)
+   enabled on their github account to gain and/or maintain their project
+   membership status. While we recognize that this may present a technical
+   barrier to some contributors, the added security to the project is
+   substantive. To set up 2FA on github, you may consult the `Github
+   documentation
+   <https://help.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa>`_
+   or you can reach out for help in any of our 
+   communication channels. 
+
+
 Groups Within the yt Project
 ----------------------------
 

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -106,3 +106,37 @@ by a vote ratio equal or exceeding to 3/5. One person on the steering
 committee shall act as the coordinator, in charge of making sure the team
 meetings happen. All developers are welcome to participate in team meetings.
 
+Defined Leadership Roles
+------------------------
+
+Within the yt project, there are a few positions that are defined so that the
+project can maintain continuity as members shift in the amount of
+responsibility they wish to take on. While project members may take on some
+responsibilities associated with these roles as they wish, at least one project
+member must be associated with each leadership role defined below. Members that
+wish to roll off of a leadership role may do so by announcing at a team
+meeting, and a new member will self-nominate to fill the position. If
+multiple members self-nominate, then members of the steering committee will
+vote to instate the new leader. Members that are in a defined leadership role
+are not necessarily steering committee members, but are red group members.  
+
+**Mentorship Shepherd** -- The mentorship shepherd helps to grow yellow group 
+members to blue group members. The mentorship shepherd will help yellow members
+find bugs and issues that they may wish to approach in the future, and, if
+necessaary, contact a blue or red team member to assist the yellow member. 
+
+**Triage Leader** -- The triage leader is responsible for ensuring that triage
+meetings get scheduled and facilitaates member participation in the triage
+meetings. The triage leader is expected to schedule and publicly announce
+triage meetings on the mailing list(s), the project slack, and 
+help new attendees understand the triage process. The triage leader will also
+tag and contact relevant knowledge experts to resolve issues or review pull
+requests, when relevant. 
+
+**The Timekeeper** -- The timekeeper helps to keep things running in the yt
+project in all ways time. This involves sending out polls to determine members'
+availability for meetings, scheduling those meetings, and running or ensuring a
+member is running a meeting. The timekeeper will announce all public meetings
+on project mailing lists, in the project slack, and, when relevant, on the
+project social media channels.  
+

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -1,8 +1,8 @@
 .. _leadership:
 
-#############
-Project Roles 
-#############
+######################
+Project-Specific Roles 
+######################
 
 yt-project Members
 ------------------
@@ -175,7 +175,7 @@ project in all ways time. This involves sending out polls to determine members'
 availability for meetings, scheduling those meetings, and running or ensuring a
 member is running a meeting. The timekeeper will announce all public meetings
 on project mailing lists, in the project slack, and, when relevant, on the
-project social media channels.
+project social media channels. 
 
 Current Leadership Members
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -127,6 +127,7 @@ Current Steering Committee Members
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Nathan Goldbaum
+| Cameron Hummels
 | Madicken Munk
 | Britton Smith
 | Stephanie Tonnesen

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -68,7 +68,7 @@ grow.
 is where the journey of a new yt project team member starts. This group is the largest 
 within the project and includes all project members and leadership group. 
 Arboretum group members
-spend a large part of your time facilitating contributions from others to the
+spend a large part of their time facilitating contributions from others to the
 project (e.g. reviewing work, answering questions, maintaining project
 infrastructure, doing triage of new issues). We expect arboretum members to teach
 and grow contributors that can become arboretum members. This encourages diversity
@@ -90,7 +90,7 @@ the project on github in their merged pull request.
 **The Fallow Fields** (can be any person, any time, self-nominated only)-- This group
 applies to members of the community whose life situation has changed so that
 they prefer to (temporarily) not take on the rights and responsibilities of
-being an active member. They may require some time off from the projec to
+being an active member. They may require some time off from the project to
 reenergize and contribute in a later season. Membership to the fallow fields is invoked by
 self-nomination. They can return to active membership by resuming their
 community activities. Their return will be announced at the next team meeting
@@ -163,7 +163,7 @@ find bugs and issues that they may wish to approach in the future, and, if
 necessaary, contact a arboretum or fertilizer team member to assist the greenhouse member. 
 
 **Triage Leader** -- The triage leader is responsible for ensuring that triage
-meetings get scheduled and facilitaates member participation in the triage
+meetings get scheduled and facilitates member participation in the triage
 meetings. The triage leader is expected to schedule and publicly announce
 triage meetings on the mailing list(s), the project slack, and 
 help new attendees understand the triage process. The triage leader will also
@@ -171,7 +171,7 @@ tag and contact relevant knowledge experts to resolve issues or review pull
 requests, when relevant. 
 
 **The Timekeeper** -- The timekeeper helps to keep things running in the yt
-project in all ways time. This involves sending out polls to determine members'
+project in all ways temporal. This involves sending out polls to determine members'
 availability for meetings, scheduling those meetings, and running or ensuring a
 member is running a meeting. The timekeeper will announce all public meetings
 on project mailing lists, in the project slack, and, when relevant, on the
@@ -183,4 +183,3 @@ Current Leadership Members
 | **Mentorship Shepherd** -- Stephanie Tonnesen
 | **Triage Leader** -- Matthew Turk
 | **The Timekeeper** -- Britton Smith
-

--- a/source/leadership.rst
+++ b/source/leadership.rst
@@ -50,12 +50,12 @@ contributors, reviewers and maintainers of the project. Each group
 encompasses many members of the community, but hopefully will help to direct
 and distribute project member energy.
 
-**Fertilizer Group** (includes executive committee, any defined leadership roles) –
+**Fertilizer Group** (includes steering committee, any defined leadership roles) –
 Members of this group spend a large part of their time organizing the
 yt-project from a high level. They are expected to coordinate their actions
 with other fertilizer members so that the project presents a coherent position towards
 the outside. They are expected to prepare and attend the monthly team calls and
-executive committee meetings. We expect fertilizer members to teach and grow other
+steering committee meetings. We expect fertilizer members to teach and grow other
 members so that they can pass their organizational responsibilities on to them.
 This encourages us to increase diversity, reduce burn-out and allow group
 members to shift their focus in reaction to changing life circumstances. If a
@@ -101,7 +101,7 @@ of the community at any level that have a prolonged leave of member duties from
 the yt project. We welcome participation in the community for any length of
 time, and this is a way to retire from the project. A project member may become
 emeritus by self-nomination or by not interacting in a membership capacity on
-the yt project for over 2 years. After this time, a member of the executive
+the yt project for over 2 years. After this time, a member of the steering
 committee will contact an inactive member and see if they wish to remain active
 or transition to an emeritus role. 
 
@@ -113,8 +113,7 @@ yt-exec@googlegroups.com.
 Steering Committee
 ------------------
 
-Members are eligible to serve on the yt project steering committee (also
-sometimes referred to as the executive committee). The
+Members are eligible to serve on the yt project steering committee. The
 steering committe shall meet quarterly or more often as needed to discuss
 project-related business. Members may join the steering committee by attending
 one of the team meetings and self-nominating. Once nominated, a nominee's entry

--- a/source/meetings.rst
+++ b/source/meetings.rst
@@ -44,10 +44,3 @@ particularly encouraged to attend to aid and facilitate
 discussion about the pull request.
 Finally, new contributors to the project are especially encouraged to attend. 
 
-Team Meetings
--------------
-
-As needed, the teams outlined in the package/subpackage groups can meet to discuss
-maintenance and feature development for focus areas within the yt project. These
-teams will announce their meetings publicly and make them accessible to members
-of the community.

--- a/source/meetings.rst
+++ b/source/meetings.rst
@@ -4,8 +4,7 @@
 Project Meetings 
 ##################
 
-All meetings associated with the yt project (with the exception of the steering
-committee) will be announced publicly to the
+All meetings associated with the yt project will be announced publicly to the
 community through communication channels, including slack, the yt-dev and yt-users 
 mailing lists. Meeting notes will be subsequently posted and announced in the
 aforementioned channels and in the `project records 
@@ -26,7 +25,10 @@ video chat to encourage remote participation, and times should be chosen to
 accomodate international attendees. The meetings invite will be public, and any
 interested developer or user is welcome to attend. When necessary, steering
 committee meetings may need to adjourn to a closed session for sensitive
-discussions. 
+discussions. The steering committee email will not be public to ensure that
+sensitivie discussions may be held on that list. However, all non-sensitive
+items will be reported and documented at subsequent public steering 
+committee meetings. 
 
 Maintainer Coworking Meetings
 -----------------------------
@@ -45,7 +47,7 @@ Finally, new contributors to the project are especially encouraged to attend.
 Team Meetings
 -------------
 
-As needed, the teams outlined in the above team structure can meet to discuss
-maintenance and feature development for areas within the yt project. These
+As needed, the teams outlined in the package/subpackage groups can meet to discuss
+maintenance and feature development for focus areas within the yt project. These
 teams will announce their meetings publicly and make them accessible to members
 of the community.

--- a/source/meetings.rst
+++ b/source/meetings.rst
@@ -1,0 +1,51 @@
+.. _meetings:
+
+##################
+Project Meetings 
+##################
+
+All meetings associated with the yt project (with the exception of the steering
+committee) will be announced publicly to the
+community through communication channels, including slack, the yt-dev and yt-users 
+mailing lists. Meeting notes will be subsequently posted and announced in the
+aforementioned channels and in the `project records 
+<https://github.com/yt-project/project-records>`_ repository. 
+All are welcome to attend, no matter their
+level of participation within the project. If part of the meeting requires a
+closed session, the meeting will adjourn to a closed meeting and notes will be
+made available at a later time. In all cases, meetings will be open for as long
+as possible.
+
+Steering Committee Meetings
+---------------------------
+
+Public meetings, optimally including all members of the steering committee,
+should happen at least once a quarter. These meetings are to encourage frank
+and open discussion about the future of the project. Meetings will happen over
+video chat to encourage remote participation, and times should be chosen to
+accomodate international attendees. The meetings invite will be public, and any
+interested developer or user is welcome to attend. When necessary, steering
+committee meetings may need to adjourn to a closed session for sensitive
+discussions. 
+
+Maintainer Coworking Meetings
+-----------------------------
+
+Twice monthly, or as required, video chats should be held to ensure timely review
+of pending maintainence of the project. This may include triaging new issues,
+reviewing new PRs, or submitting bugfixes together. These meetings will attempt
+to address all unaddressed maintenance issues, and any outstanding tasks will
+be discussed and mentioned publicly as a comment on the pull request. Any
+developer, reviewer, maintainer, or user is welcome to attend this meeting.
+Developers who have open pull requests they would like to see reviewed are
+particularly encouraged to attend to aid and facilitate 
+discussion about the pull request.
+Finally, new contributors to the project are especially encouraged to attend. 
+
+Team Meetings
+-------------
+
+As needed, the teams outlined in the above team structure can meet to discuss
+maintenance and feature development for areas within the yt project. These
+teams will announce their meetings publicly and make them accessible to members
+of the community.

--- a/source/meetings.rst
+++ b/source/meetings.rst
@@ -38,7 +38,8 @@ of pending maintainence of the project. This may include triaging new issues,
 reviewing new PRs, or submitting bugfixes together. These meetings will attempt
 to address all unaddressed maintenance issues, and any outstanding tasks will
 be discussed and mentioned publicly as a comment on the pull request. Any
-developer, reviewer, maintainer, or user is welcome to attend this meeting.
+developer, reviewer, maintainer, user, contributor, potential contributor, or
+interested party is welcome to attend this meeting.
 Developers who have open pull requests they would like to see reviewed are
 particularly encouraged to attend to aid and facilitate 
 discussion about the pull request.

--- a/source/meetings.rst
+++ b/source/meetings.rst
@@ -1,8 +1,7 @@
 .. _meetings:
 
-##################
 Project Meetings 
-##################
+################
 
 All meetings associated with the yt project will be announced publicly to the
 community through communication channels, including slack, the yt-dev and yt-users 
@@ -19,21 +18,21 @@ Steering Committee Meetings
 ---------------------------
 
 Public meetings, optimally including all members of the steering committee,
-should happen at least once a quarter. These meetings are to encourage frank
-and open discussion about the future of the project. Meetings will happen over
+happen at least once a quarter. These meetings are to encourage frank
+and open discussion about the state of the project. Meetings will happen over
 video chat to encourage remote participation, and times should be chosen to
 accomodate international attendees. The meetings invite will be public, and any
 interested developer or user is welcome to attend. When necessary, steering
 committee meetings may need to adjourn to a closed session for sensitive
 discussions. The steering committee email will not be public to ensure that
-sensitivie discussions may be held on that list. However, all non-sensitive
+sensitive discussions may be held on that list. However, all non-sensitive
 items will be reported and documented at subsequent public steering 
 committee meetings. 
 
 Maintainer Coworking Meetings
 -----------------------------
 
-Twice monthly, or as required, video chats should be held to ensure timely review
+Twice monthly, or as required, video chats will be held to ensure timely review
 of pending maintainence of the project. This may include triaging new issues,
 reviewing new PRs, or submitting bugfixes together. These meetings will attempt
 to address all unaddressed maintenance issues, and any outstanding tasks will

--- a/source/roles.rst
+++ b/source/roles.rst
@@ -51,6 +51,5 @@ Maintainers help users by answering questions on the users mailing list or in
 the yt project slack channel. Maintainers also help developers sketch out
 sustainable ways of implementing new features. Maintainers might also
 periodically go through open issues and submit bugfixes or improve
-documentation as needed to keep the project running smoothly. Often maintainers
-will be yt project members (and have commit rights to the repository), but this
-is not a hard rule nor is it required. 
+documentation as needed to keep the project running smoothly. Maintainers
+are generally yt project members (and have commit rights to the repository). 

--- a/source/roles.rst
+++ b/source/roles.rst
@@ -4,6 +4,13 @@
 Roles Within the Community 
 ##########################
 
+Often, various roles are colloquially referred to in project documentation, in
+project discussions, or in communication channels. Here we define what each
+role is, and how individuals who are active within the project may identify
+their roles. These roles are not necessarily formalized (though the contributor
+list is), but these definitions may be useful to ensure members of the project
+have a consistent convention for referring to work within the project. 
+
 Contributors/Developers
 -----------------------
 

--- a/source/roles.rst
+++ b/source/roles.rst
@@ -1,0 +1,49 @@
+.. _roles:
+
+##########################
+Roles Within the Community 
+##########################
+
+Contributors/Developers
+-----------------------
+
+Anybody who submits code to a repository within the yt project organization
+that is merged is
+considered a contributor to the project. Contributors to each package will be
+added to a list of project contributors for that package. For the core yt
+package, a `list of contributors
+<https://github.com/yt-project/yt/blob/master/CREDITS>`_ is maintained in the
+source code repository and on the `yt project website
+<https://yt-project.org/about.html>`_. For the purposes of clarity,
+contributors and developers are terms used interchangably. Contributors'
+technical contributions are expected to follow the developer guide of the
+package. For example, the code guidelines for the yt core package may be found `here
+<https://yt-project.org/doc/developing/developing.html#requirements-for-code-submission>`_ .  
+
+Reviewers
+---------
+
+Any person can be a reviewer of code submitted to the yt project. Project
+members have access to merge new code, however we strongly feel that valuable
+and important reviews may and do come from outside of the project membership.
+There is no requirement to be a project contributor/developer or maintainer to
+be a code reviewer. We also strongly encourage yt users to review code submitted to
+yt so that their experience is incorporated into new versions of the project. 
+Broadly, reviewers will
+look through code to make sure it behaves as expected, is documented
+thoroughly, is adequately tested, is appropriate for the project, and follows
+the `requirements for code submission 
+<https://yt-project.org/doc/developing/developing.html#requirements-for-code-submission>`_. 
+
+Maintainers
+-----------
+
+Project maintainers perform duties of contributors and reviewers, while also
+actively participating in the community in a number of additional ways.
+Maintainers help users by answering questions on the users mailing list or in
+the yt project slack channel. Maintainers also help developers sketch out
+sustainable ways of implementing new features. Maintainers might also
+periodically go through open issues and submit bugfixes or improve
+documentation as needed to keep the project running smoothly. Often maintainers
+will be yt project members (and have commit rights to the repository), but this
+is not a hard rule nor is it required. 

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -17,13 +17,13 @@ be decided upon. This process is summarized below.
 
 .. _decision-making:
 
-The Decision-Making Process
-----------------------------
+The Decision Making Process
+---------------------------
 
 #. The group has a discussion about the change and tries to find a resolution
    with no objections among project members. 
 
-#. If no concensus can be found in the community, or if a community member
+#. If no consensus can be found in the community, or if a community member
    requests it, then the community will have
    a vote in relevant channels (the mailing list, the YTEP, or both). The
    vote(s) will conclude two weeks after they have been called, and require a
@@ -68,7 +68,7 @@ sentence require an accepting pull request review
 by a project member, no rejecting reviews by a project member (lazy consensus). 
 Project members are expected to give “reasonable time” 
 to others to give their opinion on the pull
-request if they’re not confident others would agree. E-mails to the development
+request if they’re not confident others would agree. E-mails to the developer
 mailing list are not required for minor documentation changes. 
 
 .. _code-change-process:
@@ -95,13 +95,13 @@ requirements for merging as outlined in the first sentence of this section.
 
 .. note:: 
    While adding a new supporting frontend is generally a substantive contribution, 
-   it does not require a YTEP and falls under this category. 
+   it does not require a YTEP. 
 
 Changes to the API Principles and Changes to Dependencies or Supported Versions
 -------------------------------------------------------------------------------
 
 Changes to the API principles and changes to dependencies or supported versions
-happen via a Enhancement proposals (YTEPs) and follows the decision-making
+happen via enhancement proposals (YTEPs) and follows the decision making
 process outlined in :ref:`decision-making`. Discussions regarding these changes
 will occur in both the mailing list and the YTEP, and votes may be cast in
 either. 
@@ -113,7 +113,7 @@ either.
    depencency fall under the category of :ref:`code-change-process`.
 
 Changes to the Project Governance 
----------------------------------------
+---------------------------------
 
 Changes to the project governance model use the same decision process outlined
 in :ref:`decision-making`. These changes are high enough level to imact the
@@ -151,4 +151,3 @@ sent to the steering committee for a final vote. The vote made by the steering
 committee must be equal or greater than 3/5. Revoking membership will result in a
 loss of commit rights to yt project repositories and removal of membership from
 project pages.
-

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -30,7 +30,7 @@ Minor Documentation Changes
 
 Minor Documentation changes, such as typo fixes, or addition / correction of a
 sentence: Requires +1 by a project member, no -1 by a project member (lazy
-consensus), happens on the issue or pull request page. Project members are
+consensus), happens on the pull request page. Project members are
 expected to give “reasonable time” to others to give their opinion on the pull
 request if they’re not confident others would agree.
 

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -12,16 +12,16 @@ a private list, but the project defaults to open meetings.
 
 The yt-project uses a “consensus seeking” process for making large,
 project-changing decisions. The
-group tries to find a resolution that has no open objections among core
-developers. At any point during the discussion, any project member can call for
-a vote, which will conclude one month from the call for the vote. Any vote must
+group tries to find a resolution that has no open objections among project
+members. At any point during the discussion, any project member can call for
+a vote, which will conclude two weeks from the call for the vote. Any vote must
 be backed by a YTEP. If no option can gather two thirds of the votes cast, the
 decision is escalated to the Steering Committee, which in turn will use
 consensus seeking with the fallback option of a simple majority vote if no
 consensus can be found within a month. 
 This is what we hereafter may refer to as “the decision making process”.
 
-Decisions (in addition to adding core developers and Steering Committee
+Decisions (in addition to adding project members and Steering Committee
 membership as above) are made according to the following rules (+1 is
 equivalently an approval vote on a pull request):
 
@@ -38,7 +38,7 @@ Code Changes and Major Documentation Changes
 --------------------------------------------
 
 Code changes and major documentation changes require +1 by two project members,
-no -1 by a core developer (lazy consensus), happens on the issue of
+no -1 by a project member (lazy consensus), happens on the issue of
 pull-request page.
 
 Changes to the API Principles and Changes to Dependencies or Supported Versions
@@ -48,25 +48,33 @@ Changes to the API principles and changes to dependencies or supported versions
 happen via a Enhancement proposals (YTEPs) and follows the decision-making
 process outlined above.
 
-Changes to the Project Governance Model
+Changes to the Project Governance 
 ---------------------------------------
 
 Changes to the project governance model use the same decision process outlined
-above.
-If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
-community and core developers and the change can be approved or rejected using
-the decision making procedure outlined above.
+above. 
 
-**Note** Project members are expected to attempt to resolve issues with
-the contributor before casting a veto vote. Resolving issues here may be
-proposing alternative implementations, alternative language, or a variant of
-the solution that the project member feels is more workable. Project members
-are expected to use veto votes sparingly. 
+Changes to the governance documents which do not impact the high-level model
+follow the same process as *code changes and major documentation changes*.
+
+.. note:: 
+   If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
+   community and project members and the change can be approved or rejected using
+   the decision making procedure outlined above.
+
+.. important:: 
+   Project members are expected to attempt to resolve issues with
+   the contributor before casting a veto vote. Resolving issues here may be
+   proposing alternative implementations, alternative language, or a variant of
+   the solution that the project member feels is more workable. Project members
+   are expected to use veto votes sparingly. 
 
 Project Membership
 ------------------
 
-**Entry** A member is someone who has made continued and significant contribution to the
+**Entry** 
+
+A member is someone who has made continued and significant contribution to the
 project (changes to the codebase, discussion on mailing lists, feedback on pull
 requests, documentation, teaching, etc.) for some period of time. 
 After such a period, potential new members are nominated for membership by an
@@ -75,12 +83,14 @@ Once a developer becomes a member, they remain a member for life. A member
 maintains the option to give up their membership and have their name removed
 from the list. 
 
-**Removal** Finally, project membership may be revoked for anyone who is deemed to be
+**Removal** 
+
+Finally, project membership may be revoked for anyone who is deemed to be
 directly harmful to the project or the community upon a nomination by another
 member and five supporting member votes. Once five supporting member votes are
 reached, the member is nominated for revoked membership and the decision is
 sent to the steering committee for a final vote. The vote made by the steering
-committee must be greater than 3/5. Revoking membership will result in a
+committee must be equal or greater than 3/5. Revoking membership will result in a
 loss of commit rights to yt project repositories and removal of membership from
 project pages.
 

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -11,63 +11,118 @@ project meetings mentioned above. Occasionally, sensitive discussion occurs on
 a private list, but the project defaults to open meetings.
 
 The yt-project uses a “consensus seeking” process for making large,
-project-changing decisions. The
-group tries to find a resolution that has no open objections among project
-members. At any point during the discussion, any project member can call for
-a vote, which will conclude two weeks from the call for the vote. Any vote must
-be backed by a YTEP. If no option can gather two thirds of the votes cast, the
-decision is escalated to the Steering Committee, which in turn will use
-consensus seeking with the fallback option of a simple majority vote if no
-consensus can be found within a month. 
+project-changing decisions. This approach has a series of decision-making
+fallbacks to help ensure that all contributions to the project will eventually
+be decided upon. This process is summarized below. 
+
+.. _decision-making:
+
+The Decision-Making Process
+----------------------------
+
+#. The group has a discussion about the change and tries to find a resolution
+   with no objections among project members. 
+
+#. If no concensus can be found in the community, or if a community member
+   requests it, then the community will have
+   a vote in relevant channels (the mailing list, the YTEP, or both). The
+   vote(s) will conclude two weeks after they have been called, and require a
+   2/3 majority to pass. If both modes of voting are active (e.g. in the
+   mailing list and the YTEP), a 2/3 majority in either will result in a
+   passing vote. 
+
+#. If no 2/3 majority is found in the vote(s) cast, then the decision is
+   escalated to the steering committee. The steering committee will try to find
+   a consensus within a month of the initial escalation in case members of 
+   the steering committee are
+   unable to participate in the discussion for whatever reason. 
+
+#. If the steering committee cannot find a consensus, then they fall back to a
+   majority vote. 
+
 This is what we hereafter may refer to as “the decision making process”.
 
+.. note:: 
+   If a veto -1 vote or rejecting review is cast on a lazy consensus (e.g. on a
+   documentation change where the full decision making process is not required), 
+   the proposer/author can appeal to the
+   community and project members and the change can be approved or rejected using
+   the decision making procedure outlined above.
+
+.. important:: 
+   Project members are expected to attempt to resolve issues with
+   the contributor before casting a veto vote or rejecting review. 
+   Resolving issues here may be
+   proposing alternative implementations, alternative language, or a variant of
+   the solution that the project member feels is more workable. Project members
+   are expected to use veto votes and rejecting reviews sparingly. 
+
 Decisions (in addition to adding project members and Steering Committee
-membership as above) are made according to the following rules (+1 is
-equivalently an approval vote on a pull request):
+membership) are made according to the following rules:
 
 Minor Documentation Changes
 ---------------------------
 
 Minor Documentation changes, such as typo fixes, or addition / correction of a
-sentence: Requires +1 by a project member, no -1 by a project member (lazy
-consensus), happens on the pull request page. Project members are
-expected to give “reasonable time” to others to give their opinion on the pull
-request if they’re not confident others would agree.
+sentence require an accepting pull request review 
+by a project member, no rejecting reviews by a project member (lazy consensus). 
+Project members are expected to give “reasonable time” 
+to others to give their opinion on the pull
+request if they’re not confident others would agree. E-mails to the development
+mailing list are not required for minor documentation changes. 
+
+.. _code-change-process:
 
 Code Changes and Major Documentation Changes
 --------------------------------------------
 
-Code changes and major documentation changes require +1 by two project members,
-no -1 by a project member (lazy consensus), happens on the issue of
-pull-request page.
+Code changes and major documentation changes in a pull request require approving reviews 
+by two project members,
+no rejecting reviews by a project member (lazy consensus). At any point in
+the pull request review process a reviewer may request that the author e-mail
+the development mailing list to continue the discussion outside of the pull
+request. An e-mail to yt-dev is not always required for changes of this
+magnitude, but it is an avenue that may be necessary to ensure that the change
+is in accordance with the project style and philosophy. If the code change is
+substantive enough, a member may request that the change be backed by a YTEP.  
+
+If a change of this magnitude 
+is proposed in an issue or the mailing list before a pull request is submitted, 
+the project recommends  
+that the issue receive positive/affirmitive feedback by at least one project
+member before a PR is submitted. The submitted PR will then go through the same
+requirements for merging as outlined in the first sentence of this section. 
+
+.. note:: 
+   While adding a new supporting frontend is generally a substantive contribution, 
+   it does not require a YTEP and falls under this category. 
 
 Changes to the API Principles and Changes to Dependencies or Supported Versions
 -------------------------------------------------------------------------------
 
 Changes to the API principles and changes to dependencies or supported versions
 happen via a Enhancement proposals (YTEPs) and follows the decision-making
-process outlined above.
+process outlined in :ref:`decision-making`. Discussions regarding these changes
+will occur in both the mailing list and the YTEP, and votes may be cast in
+either. 
+
+.. note:: 
+   A YTEP is only required for adding a new hard dependency. Adding an optional 
+   dependency does not necessarily require a YTEP, but may be called for by a code
+   reviewer if necessary. In general, code contributions that add an optional
+   depencency fall under the category of :ref:`code-change-process`.
 
 Changes to the Project Governance 
 ---------------------------------------
 
 Changes to the project governance model use the same decision process outlined
-above. 
+in :ref:`decision-making`. These changes are high enough level to imact the
+governance YTEP and the governance documentation.  
 
 Changes to the governance documents which do not impact the high-level model
-follow the same process as *code changes and major documentation changes*.
-
-.. note:: 
-   If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
-   community and project members and the change can be approved or rejected using
-   the decision making procedure outlined above.
-
-.. important:: 
-   Project members are expected to attempt to resolve issues with
-   the contributor before casting a veto vote. Resolving issues here may be
-   proposing alternative implementations, alternative language, or a variant of
-   the solution that the project member feels is more workable. Project members
-   are expected to use veto votes sparingly. 
+follow the same process as in :ref:`code-change-process`. These changes will
+generally not affect the governance YTEP but may enhance or clarify the
+existing governance documentation. 
 
 Project Membership
 ------------------
@@ -79,6 +134,9 @@ project (changes to the codebase, discussion on mailing lists, feedback on pull
 requests, documentation, teaching, etc.) for some period of time. 
 After such a period, potential new members are nominated for membership by an
 existing member and confirmed by positive votes from three additional members.
+Nomination can happen in the yt-dev mailing list or in a team meeting. If a
+nomination and vote do occur in a team meeting, the nomination and vote must be
+documented in the meeting notes. 
 Once a developer becomes a member, they remain a member for life. A member
 maintains the option to give up their membership and have their name removed
 from the list. 

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -1,0 +1,86 @@
+.. _voting:
+
+############
+Voting Items
+############
+
+Decisions about the future of the project are made through discussion with all
+members of the community. All non-sensitive project management discussion takes
+place on the project developers’ mailing list, the issue tracker, and in the
+project meetings mentioned above. Occasionally, sensitive discussion occurs on
+a private list, but the project defaults to open meetings.
+
+The yt-project uses a “consensus seeking” process for making large,
+project-changing decisions. The
+group tries to find a resolution that has no open objections among core
+developers. At any point during the discussion, any project member can call for
+a vote, which will conclude one month from the call for the vote. Any vote must
+be backed by a YTEP. If no option can gather two thirds of the votes cast, the
+decision is escalated to the Steering Committee, which in turn will use
+consensus seeking with the fallback option of a simple majority vote if no
+consensus can be found within a month. 
+This is what we hereafter may refer to as “the decision making process”.
+
+Decisions (in addition to adding core developers and Steering Committee
+membership as above) are made according to the following rules (+1 is
+equivalently an approval vote on a pull request):
+
+Minor Documentation Changes
+---------------------------
+
+Minor Documentation changes, such as typo fixes, or addition / correction of a
+sentence: Requires +1 by a project member, no -1 by a project member (lazy
+consensus), happens on the issue or pull request page. Project members are
+expected to give “reasonable time” to others to give their opinion on the pull
+request if they’re not confident others would agree.
+
+Code Changes and Major Documentation Changes
+--------------------------------------------
+
+Code changes and major documentation changes require +1 by two project members,
+no -1 by a core developer (lazy consensus), happens on the issue of
+pull-request page.
+
+Changes to the API Principles and Changes to Dependencies or Supported Versions
+-------------------------------------------------------------------------------
+
+Changes to the API principles and changes to dependencies or supported versions
+happen via a Enhancement proposals (YTEPs) and follows the decision-making
+process outlined above.
+
+Changes to the Project Governance Model
+---------------------------------------
+
+Changes to the project governance model use the same decision process outlined
+above.
+If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
+community and core developers and the change can be approved or rejected using
+the decision making procedure outlined above.
+
+**Note** Project members are expected to attempt to resolve issues with
+the contributor before casting a veto vote. Resolving issues here may be
+proposing alternative implementations, alternative language, or a variant of
+the solution that the project member feels is more workable. Project members
+are expected to use veto votes sparingly. 
+
+Project Membership
+------------------
+
+**Entry** A member is someone who has made continued and significant contribution to the
+project (changes to the codebase, discussion on mailing lists, feedback on pull
+requests, documentation, teaching, etc.) for some period of time. 
+After such a period, potential new members are nominated for membership by an
+existing member and confirmed by positive votes from three additional members.
+Once a developer becomes a member, they remain a member for life. A member
+maintains the option to give up their membership and have their name removed
+from the list. 
+
+**Removal** Finally, project membership may be revoked for anyone who is deemed to be
+directly harmful to the project or the community upon a nomination by another
+member and five supporting member votes. Once five supporting member votes are
+reached, the member is nominated for revoked membership and the decision is
+sent to the steering committee for a final vote. The vote made by the steering
+committee must be greater than 3/5. Revoking membership will result in a
+loss of commit rights to yt project repositories and removal of membership from
+project pages.
+


### PR DESCRIPTION
This PR updates the existing yt project governance and separates it out into some nicely formatted sphinx documentation. 

Some improvements:
- defines roles of different members of the community
- defines teams with the goal of creating a developer mentorship structure (and also focusing developer time to specific areas of the project). This hopefully will help distribute our maintainer burden as well
- defines voting items and what votes are required for various changes in the project
- removes some specifics of development process from ytep-1776. This is with the idea that that can be isolated to the developer guide rather than in the governance structure. 

Some things to consider:
- do we want to have the consensus making procedure that is suggested here? I'm not sure, and this is just temporary
- do we want to have the red/blue/green/emeritus groups AND the subproject teams? This could be too much, but the subproject teams might make development a little more approachable for people new to the project? And it could help distribute maintainer load by focusing people to different areas? But the red/blue/green structure might suit the size of our project better. 
- do we want to make executive committee meetings public or not? 
- do we set some standards with a maximum size for the coworking meetings so that people can effectively communicate? (If 20 people are on the call, will it be useful? Maybe then it should split to specific maintainer areas.) 

All of this is just a proposal, so please feel free to give feedback on how to make this more readable, more approachable, or if you think there could be a better/more effective process to follow! 