### PR TITLE
Modify voting requirements for minor bugfixes

### DIFF
--- a/source/general.rst
+++ b/source/general.rst
@@ -30,7 +30,7 @@ through the following procedure:
 * The pull request is announced in public channels available to the community and 
   must be discussed at the next steering committee meeting.
 * The alternative model is accepted by more than half of the active members 
-  of that repository and at least two executive committee members.
+  of that repository and at least two steering committee members.
 
 Unless specifically stated otherwise this governance document and topics within
 will apply to all repositories within the organization.

--- a/source/voting.rst
+++ b/source/voting.rst
@@ -60,12 +60,16 @@ This is what we hereafter may refer to as “the decision making process”.
 Decisions (in addition to adding project members and Steering Committee
 membership) are made according to the following rules:
 
-Minor Documentation Changes
----------------------------
+Minor Documentation Changes and Small Bugfixes
+----------------------------------------------
 
 Minor Documentation changes, such as typo fixes, or addition / correction of a
 sentence require an accepting pull request review 
 by a project member, no rejecting reviews by a project member (lazy consensus). 
+Small bugfixes that change a few lines of code and restore or fix broken API
+may also be merged with a single accepting pull request review by a project
+member. Note that major bugfixes that include refactoring and larger changes to
+the codebase will fall under the next category listed on this page. 
 Project members are expected to give “reasonable time” 
 to others to give their opinion on the pull
 request if they’re not confident others would agree. E-mails to the development


### PR DESCRIPTION
It was brought up in yt development channels that small bugfixes reasonably could require one approving review for merging. That seems reasonable. I've added some language (and tried to distinguish from larger bugfixes) to allow for those types of reviews. 

